### PR TITLE
Added some tests and fixed parsing to support the way monit sends email

### DIFF
--- a/smtpd/smtpd.go
+++ b/smtpd/smtpd.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	rcptToRE = regexp.MustCompile(`[Tt][Oo]:<(.+)>`)
+	rcptToRE = regexp.MustCompile(`[Tt][Oo]:\s*<(.+)>`)
 	//mailFromRE = regexp.MustCompile(`(?i)^from:\s*<(.*?)>`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:<(.*)>`)
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\s*<(.*)>`)
 )
 
 // Server is an SMTP server.

--- a/smtpd/smtpd_test.go
+++ b/smtpd/smtpd_test.go
@@ -1,0 +1,105 @@
+package smtpd
+
+import (
+	"testing"
+	"bytes"
+	"fmt"
+	"net/smtp"
+	"net"
+	"time"
+)
+
+var newMailWasReceived bool
+
+func TestSmtpdServer(t *testing.T) {
+	newMailWasReceived = false
+	srvPort := startServer()
+
+	conn, err := smtp.Dial(fmt.Sprintf("localhost:%d", srvPort))
+	for err != nil {
+		conn, err = smtp.Dial(fmt.Sprintf("localhost:%d", srvPort))
+	}
+	defer conn.Close()
+
+	conn.Mail("sender@example.org")
+	conn.Rcpt("recipient@example.net")
+
+	writeCloser, err := conn.Data()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer writeCloser.Close()
+
+	buf := bytes.NewBufferString(`Hello World!`)
+	buf.WriteTo(writeCloser)
+
+	if newMailWasReceived != true {
+		t.Fatalf("Email was not received")
+	}
+}
+
+func TestSmtpdServerWithMonit(t *testing.T) {
+	newMailWasReceived = false
+	srvPort := startServer()
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", srvPort))
+	for err != nil {
+		conn, err = net.Dial("tcp", fmt.Sprintf("localhost:%d", srvPort))
+	}
+	defer conn.Close()
+
+	emailBytes := [][]byte{
+		[]byte("Hello\r\n"),
+		[]byte("MAIL FROM: <monit@localhost>\r\n"),
+		[]byte("RCPT TO: <recipient@localhost>\r\n"),
+		[]byte("data\r\n"),
+		[]byte("From: sender@example.org\r\n"),
+		[]byte("Subject: test mail from command line\r\n"),
+		[]byte("\r\n"),
+		[]byte("Message-id: <1304319946.0@localhost>\r\n"),
+		[]byte("Service: nats\r\n"),
+		[]byte("Event: does not exist\r\n"),
+		[]byte("Action: restart\r\n"),
+		[]byte("Date: Sun, 22 May 2011 20:07:41 +0500\r\n"),
+		[]byte("Description: process is not running\r\n"),
+		[]byte(".\r\n"),
+	}
+
+	for _, b := range emailBytes {
+		_, err = conn.Write(b)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	if newMailWasReceived != true {
+		t.Fatalf("Email was not received")
+	}
+}
+
+func startServer() (port int) {
+	onNewMail := func(Connection, MailAddress) (env Envelope, err error) {
+		newMailWasReceived = true
+		env = new(BasicEnvelope)
+		return
+	}
+
+	port = getTestServerPort()
+	serv := &Server{
+		Addr:      fmt.Sprintf(":%d", port),
+		OnNewMail: onNewMail,
+	}
+
+	go serv.ListenAndServe()
+	return
+}
+
+var testServerPort int = 2500
+
+func getTestServerPort() int {
+	testServerPort++
+	return testServerPort
+}


### PR DESCRIPTION
Hi,

we are working on capturing emails from monit to redirect the alerts using our go program.
When trying it we ran into the following error:

```
invalid MAIL arg: "FROM: <monit@72511f54-196e-4cdc-aeab-54ad70db783d>"
```

So we added a couple tests to cover the basic sending of an email with or without monit style headers...

Thanks!

Signed-off-by: Ben Smith bsmith@pivotallabs.com
