### PR TITLE
Handle errors returned by Close(), if any.

### DIFF
--- a/smtpd/smtpd.go
+++ b/smtpd/smtpd.go
@@ -343,7 +343,10 @@ func (s *session) handleData() {
 			return
 		}
 	}
-	s.env.Close()
+	if err := s.env.Close(); err != nil {
+		s.handleError(err)
+		return
+	}
 	s.sendlinef("250 2.0.0 Ok: queued")
 	s.env = nil
 }


### PR DESCRIPTION
Since the Close() function seems to be a callback that happens during end of data, shouldn't s.sendlinef("250 2.0.0 Ok: queued") be done only after handling any errors that the User wants to return from Close()?
